### PR TITLE
Haoyuanli add gwas browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "homepage": "https://github.com/CanDIG/candigv2_dashboard",
   "dependencies": {
+    "igv": "2.6.3",
     "@highcharts/map-collection": "^1.1.3",
     "bootstrap": "4.5.0",
     "chart.js": "2.9.3",

--- a/src/components/IGV/GwasInstance.js
+++ b/src/components/IGV/GwasInstance.js
@@ -42,7 +42,11 @@ function GwasInstance({selectedGwasName, selectedGwasUrl}) {
     });
 
     return (
-        <div className="ml-auto mr-auto" style={{background: "white", marginTop: "15px"}} ref={igvBrowser}></div>
+        <div 
+            className="ml-auto mr-auto" 
+            style={{background: "white", marginTop: "15px"}} 
+            ref={igvBrowser}>
+        </div>
     )
 }
 

--- a/src/components/IGV/GwasInstance.js
+++ b/src/components/IGV/GwasInstance.js
@@ -39,7 +39,7 @@ function GwasInstance({selectedGwasName, selectedGwasUrl}) {
             igvOptions["tracks"][0]["url"] = selectedGwasUrl;
             igv.createBrowser(igvBrowser.current, igvOptions);
         }
-    })
+    });
 
     return (
         <div className="ml-auto mr-auto" style={{background: "white", marginTop: "15px"}} ref={igvBrowser}></div>

--- a/src/components/IGV/GwasInstance.js
+++ b/src/components/IGV/GwasInstance.js
@@ -1,0 +1,49 @@
+import React, { useRef, useEffect } from "react";
+
+// TODO: Importing from igv.esm.min.js is not working
+import igv from 'igv/dist/igv.esm.js'
+
+function GwasInstance({selectedGwasName, selectedGwasUrl}) {
+    /***
+    * A functional component that returns an IGV.js instance dedicated to rendering GWAS data.
+    */
+    const igvBrowser = useRef(null);
+    const igvOptions = {
+        genome: 'hg38',
+        tracks: [
+          {
+              type: "gwas",
+              format: "gwas",
+              name: "",
+              url: "",
+              indexed: false,
+              height: 300,
+              columns: {
+                  chromosome: 1,
+                  position: 2,
+                  value: 5
+              },
+              dotSize: 2.2
+          }
+      ]};
+
+    useEffect(() => {
+        // Remove existing browser instances
+        while (igv.getBrowser() !== undefined) {
+            igv.removeBrowser(igv.getBrowser());
+        }
+
+        // Do not create new browser instance on page load as no sample is selected.
+        if (selectedGwasName !== "") {
+            igvOptions["tracks"][0]["name"] = selectedGwasName;
+            igvOptions["tracks"][0]["url"] = selectedGwasUrl;
+            igv.createBrowser(igvBrowser.current, igvOptions);
+        }
+    })
+
+    return (
+        <div className="ml-auto mr-auto" style={{background: "white", marginTop: "15px"}} ref={igvBrowser}></div>
+    )
+}
+
+export default GwasInstance;

--- a/src/views/GwasBrowser.js
+++ b/src/views/GwasBrowser.js
@@ -1,8 +1,6 @@
-import React, { useRef, useState, useEffect } from "react";
+import React, { useState } from "react";
 import { Row, Input, UncontrolledAlert } from "reactstrap";
-
-// TODO: Importing from igv.esm.min.js is not working, but it works fine in the standalone test
-import igv from 'igv/dist/igv.esm.js'
+import GwasInstance from "../components/IGV/GwasInstance.js"
 
 // Consts
 import BASE_URL from "../constants/constants.js"
@@ -10,28 +8,10 @@ import BASE_URL from "../constants/constants.js"
 
 function GwasBrowser() {
   /***
-   * A functional component that renders an IGV.js instance
+   * A functional component that renders a view with a IGV.js browser.
    */
   const [selectedGwasName, setSelectedGwasName] = useState("");
-  const igvBrowser = useRef(null);
-  const igvOptions = {
-    genome: 'hg38',
-    tracks: [
-      {
-          type: "gwas",
-          format: "gwas",
-          name: "",
-          url: "",
-          indexed: false,
-          height: 300,
-          columns: {
-              chromosome: 1,
-              position: 2,
-              value: 5
-          },
-          dotSize: 2.2
-      }
-  ]};
+  const [selectedGwasUrl, setSelectedGwasUrl] = useState("");
 
   const mock_data = {
     "ANA_A2_V2_filtered": "/static/COVID19_HGI_ANA_A2_V2_20200701.txt.gz_1.0E-5.txt",
@@ -54,20 +34,6 @@ function GwasBrowser() {
       </option>
     );
   });
-
-  useEffect(() => {
-    // Remove an existing browser instance
-    while (igv.getBrowser() !== undefined) {
-      igv.removeBrowser(igv.getBrowser());
-    }
-
-    // Do not create new browser instance on page load as no sample is selected.
-    if (selectedGwasName !== "") {
-      igvOptions["tracks"][0]["name"] = selectedGwasName;
-      igvOptions["tracks"][0]["url"] = BASE_URL + mock_data[selectedGwasName];
-      igv.createBrowser(igvBrowser.current, igvOptions);
-    }
-  }, [selectedGwasName, setSelectedGwasName])
 
   return (
     <>
@@ -94,12 +60,13 @@ function GwasBrowser() {
             <Input defaultValue={'disabled'}
               onChange={(e) => {
                 setSelectedGwasName(e.currentTarget.value);
+                setSelectedGwasUrl(BASE_URL + mock_data[e.currentTarget.value]);
               }}
               type="select">
               { disabledElementList.concat(gwasList) }
             </Input>
 
-            <div className="ml-auto mr-auto" style={{background: "white", marginTop: "15px"}} ref={igvBrowser}></div>
+            <GwasInstance selectedGwasName={selectedGwasName} selectedGwasUrl={selectedGwasUrl} />
         </div>
     </>
   );

--- a/src/views/GwasBrowser.js
+++ b/src/views/GwasBrowser.js
@@ -51,14 +51,14 @@ function GwasBrowser() {
   });
 
   useEffect(() => {
-
     // Remove an existing browser instance
     if (igv.getBrowser() !== undefined) {
       igv.removeBrowser(igv.getBrowser());
     }
 
     // Do not create new browser instance when nothing is selected
-    if (selectedGwasName != "") {
+    // This resolves a bug when two IGV instances are rendered
+    if (selectedGwasName !== "") {
       igvOptions["tracks"][0]["name"] = selectedGwasName;
       igvOptions["tracks"][0]["url"] = BASE_URL + mock_data[selectedGwasName];
       igv.createBrowser(igvBrowser.current, igvOptions);

--- a/src/views/GwasBrowser.js
+++ b/src/views/GwasBrowser.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useRef, useState, useEffect } from "react";
 import { Row, Input } from "reactstrap";
 
 // TODO: Importing from igv.esm.min.js is not working, but it works fine in the standalone test
@@ -8,119 +8,79 @@ import igv from 'igv/dist/igv.esm.js'
 import BASE_URL from "../constants/constants.js"
 
 
-class GwasBrowser extends React.Component {
-    constructor(props) {
-        super(props);
-        this.state = {
-            selectedGwasName: ""
-        }
-        this.igvBrowserRef = React.createRef();
-        this.gwasFileList = {};
-        this.igvOptions =  {
-          genome: 'hg38',
-          tracks: [
-            {
-                type: "gwas",
-                format: "gwas",
-                name: "",
-                url: "",
-                indexed: false,
-                height: 300,
-                columns: {
-                    chromosome: 1,
-                    position: 2,
-                    value: 5
-                },
-                dotSize: 1.5
-            }
-        ]}
-    }
-    
-    /**
-     * Invoked when this.state.selectedGwasName is updated
-     */
-    componentDidUpdate(prevState) {
-      //TODO: Use igv.removeBrowser to remove existing browser instance
-
-        if (this.state.selectedGwasName !== prevState.selectedGwasName) {
-            this.igvOptions["tracks"][0]["name"] = this.state.selectedGwasName;
-            this.igvOptions["tracks"][0]["url"] = BASE_URL + this.gwasFileList[this.state.selectedGwasName]
-
-            for (let i = 0; i < this.igvBrowserRef.current.childNodes.length; i++){
-              let curr = this.igvBrowserRef.current.childNodes[i];
-              if (curr.className === "igv-root-div") {
-                curr.remove();
-              }
-            }
-            this.igvBrowserRef.current.remove()
-            igv.createBrowser(this.igvBrowserRef.current, this.igvOptions);
-        }
-    }
-
-    /**
-     * Invoked when a different option of dropdown is selected.
-     */
-    handleGwasInputClick = (e) => {
-        this.setState({ selectedGwasName: e.target.value});
-    };
-
-    /*
-    * Create dropdown for gwas data files
-    * This method is invoked in render()
-    */
-    buildGwasList() {
-      // This should be replaced by an XHR request that retrieves a list of files from an API Server
-      var mock_data = {
-        "ANA_A2_V2_filtered": "/static/COVID19_HGI_ANA_A2_V2_20200701.txt.gz_1.0E-5.txt",
-        "ANA_B1_V2": "/static/COVID19_HGI_ANA_B1_V2.gwas", 
-        "ANA_B2_V2": "/static/minimal.gwas.1e-2.txt",
-        "ANA_C1_V2_filtered": "/static/COVID19_HGI_ANA_C1_V2_20200701.txt.gz_1.0E-5.txt",
-        "ANA_D1_V2_filtered": "/static/COVID19_HGI_ANA_D1_V2_20200701.txt.gz_1.0E-5.txt"
+function GwasBrowser() {
+  /***
+   * A functional component that renders an IGV.js instance
+   * 
+   */
+  const [selectedGwasName, setSelectedGwasName] = useState("");
+  const igvBrowser = useRef(null);
+  const igvOptions = {
+    genome: 'hg38',
+    tracks: [
+      {
+          type: "gwas",
+          format: "gwas",
+          name: "",
+          url: "",
+          indexed: false,
+          height: 300,
+          columns: {
+              chromosome: 1,
+              position: 2,
+              value: 5
+          },
+          dotSize: 1.5
       }
+  ]};
 
-      this.gwasFileList = mock_data;
-
-      return Object.keys(mock_data).map((x) => {
-          return (
-            <option key={x} value={x}>
-              {x}
-            </option>
-          );
-        });
-    }
-
-
-    /**
-     * Invoked when render() completes
-     * By default, load the first gwas file available.
-     */
-    componentDidMount() {
-      // Use the first gwas file name as the initial state
-      this.setState({ selectedGwasName: Object.keys(this.gwasFileList)[0] });
-      this.igvOptions["tracks"][0]["name"] = this.state.selectedGwasName;
-      this.igvOptions["tracks"][0]["url"] = BASE_URL + this.gwasFileList[this.state.selectedGwasName]
-
-    }
-
-    render() {
-      return (
-        <>
-            <div className="content">
-                <Row>
-                    <Input onChange={this.handleGwasInputClick} type="select">
-                        { this.buildGwasList() }
-                    </Input>
-                </Row>
-                <div ref={this.igvBrowserRef}></div>
-            </div>
-        </>
-      );
-    }
+  const mock_data = {
+    "ANA_A2_V2_filtered": "/static/COVID19_HGI_ANA_A2_V2_20200701.txt.gz_1.0E-5.txt",
+    "ANA_B1_V2": "/static/COVID19_HGI_ANA_B1_V2.gwas", 
+    "ANA_B2_V2": "/static/minimal.gwas.1e-2.txt",
+    "ANA_C1_V2_filtered": "/static/COVID19_HGI_ANA_C1_V2_20200701.txt.gz_1.0E-5.txt",
+    "ANA_D1_V2_filtered": "/static/COVID19_HGI_ANA_D1_V2_20200701.txt.gz_1.0E-5.txt"
   }
 
-//   ReactDOM.render(
-//     <GwasBrowser />,
-//     document.getElementById('root')
-//   );
+  const gwasList = Object.keys(mock_data).map((x) => {
+    return (
+      <option key={x} value={x}>
+        {x}
+      </option>
+    );
+  });
 
-  export default GwasBrowser;
+  useEffect(() => {
+
+    // Remove an existing browser instance
+    if (igv.getBrowser() !== undefined) {
+      igv.removeBrowser(igv.getBrowser());
+    }
+
+    // Do not create new browser instance when nothing is selected
+    if (selectedGwasName != "") {
+      igvOptions["tracks"][0]["name"] = selectedGwasName;
+      igvOptions["tracks"][0]["url"] = BASE_URL + mock_data[selectedGwasName];
+      igv.createBrowser(igvBrowser.current, igvOptions);
+    }
+  })
+
+  return (
+    <>
+        <div className="content">
+            <Row>
+                <Input 
+                  onChange={(e) => {
+                    setSelectedGwasName(e.currentTarget.value);
+                  }}
+                  type="select">
+                  { gwasList }
+                </Input>
+            </Row>
+            <div ref={igvBrowser}></div>
+        </div>
+    </>
+  );
+}
+
+export default GwasBrowser;

--- a/src/views/GwasBrowser.js
+++ b/src/views/GwasBrowser.js
@@ -35,12 +35,13 @@ class GwasBrowser extends React.Component {
         ]}
     }
     
-    /*
-    * Invoked when this.state.selectedGwasName is updated
-    */
+    /**
+     * Invoked when this.state.selectedGwasName is updated
+     */
     componentDidUpdate(prevState) {
         if (this.state.selectedGwasName !== prevState.selectedGwasName) {
             var igvContainer = document.getElementById('igv-div');
+            document.getElementById("igv-div").innerHTML = ""
 
             this.igvOptions["tracks"][0]["name"] = this.state.selectedGwasName;
             this.igvOptions["tracks"][0]["url"] = BASE_URL + this.gwasFileList[this.state.selectedGwasName]
@@ -89,7 +90,7 @@ class GwasBrowser extends React.Component {
       var igvContainer = document.getElementById('igv-div');
 
       // Use the first gwas file name as the initial state
-      this.state.selectedGwasName = Object.keys(this.gwasFileList)[0];
+      this.setState({ selectedGwasName: Object.keys(this.gwasFileList)[0] });
 
       this.igvOptions["tracks"][0]["name"] = this.state.selectedGwasName;
       this.igvOptions["tracks"][0]["url"] = BASE_URL + this.gwasFileList[this.state.selectedGwasName]
@@ -103,7 +104,7 @@ class GwasBrowser extends React.Component {
             <div className="content">
                 <Row>
                     <Input onChange={this.handleGwasInputClick} type="select">
-                        { this.buildGwasList()}
+                        { this.buildGwasList() }
                     </Input>
                 </Row>
                 <div id="igv-div"></div>

--- a/src/views/GwasBrowser.js
+++ b/src/views/GwasBrowser.js
@@ -45,6 +45,14 @@ class GwasBrowser extends React.Component {
         if (this.state.selectedGwasName !== prevState.selectedGwasName) {
             this.igvOptions["tracks"][0]["name"] = this.state.selectedGwasName;
             this.igvOptions["tracks"][0]["url"] = BASE_URL + this.gwasFileList[this.state.selectedGwasName]
+
+            for (let i = 0; i < this.igvBrowserRef.current.childNodes.length; i++){
+              let curr = this.igvBrowserRef.current.childNodes[i];
+              if (curr.className === "igv-root-div") {
+                curr.remove();
+              }
+            }
+            this.igvBrowserRef.current.remove()
             igv.createBrowser(this.igvBrowserRef.current, this.igvOptions);
         }
     }
@@ -92,7 +100,6 @@ class GwasBrowser extends React.Component {
       this.igvOptions["tracks"][0]["name"] = this.state.selectedGwasName;
       this.igvOptions["tracks"][0]["url"] = BASE_URL + this.gwasFileList[this.state.selectedGwasName]
 
-      igv.createBrowser(this.igvBrowserRef.current, this.igvOptions);
     }
 
     render() {

--- a/src/views/GwasBrowser.js
+++ b/src/views/GwasBrowser.js
@@ -1,5 +1,5 @@
 import React, { useRef, useState, useEffect } from "react";
-import { Row, Input } from "reactstrap";
+import { Row, Input, UncontrolledAlert } from "reactstrap";
 
 // TODO: Importing from igv.esm.min.js is not working, but it works fine in the standalone test
 import igv from 'igv/dist/igv.esm.js'
@@ -73,15 +73,33 @@ function GwasBrowser() {
     <>
         <div className="content">
             <Row>
-                <Input defaultValue={'disabled'}
-                  onChange={(e) => {
-                    setSelectedGwasName(e.currentTarget.value);
-                  }}
-                  type="select">
-                  { disabledElementList.concat(gwasList) }
-                </Input>
+              <UncontrolledAlert color="info" className="ml-auto mr-auto alert-with-icon" fade={false}>
+                  <span
+                    data-notify="icon"
+                    className="nc-icon nc-bell-55"
+                  />
+
+                  <b>
+                    <span>
+                      <p> Reminders: </p>
+                      <p> Select a sample to get started. </p>
+                      <p> To adjust the range of data being plotted, click on the setting icon on the right
+                      of the track and select "Autoscale", or manually adjust the range by clicking on "Set data range".</p>
+                      <p> To adjust the height of the track, use "Set track height". </p>
+                    </span>
+                  </b>
+              </UncontrolledAlert>
             </Row>
-            <div ref={igvBrowser}></div>
+
+            <Input defaultValue={'disabled'}
+              onChange={(e) => {
+                setSelectedGwasName(e.currentTarget.value);
+              }}
+              type="select">
+              { disabledElementList.concat(gwasList) }
+            </Input>
+
+            <div className="ml-auto mr-auto" style={{background: "white", marginTop: "15px"}} ref={igvBrowser}></div>
         </div>
     </>
   );

--- a/src/views/GwasBrowser.js
+++ b/src/views/GwasBrowser.js
@@ -11,7 +11,6 @@ import BASE_URL from "../constants/constants.js"
 function GwasBrowser() {
   /***
    * A functional component that renders an IGV.js instance
-   * 
    */
   const [selectedGwasName, setSelectedGwasName] = useState("");
   const igvBrowser = useRef(null);

--- a/src/views/GwasBrowser.js
+++ b/src/views/GwasBrowser.js
@@ -19,13 +19,13 @@ function GwasBrowser() {
     "ANA_B2_V2": "/static/minimal.gwas.1e-2.txt",
     "ANA_C1_V2_filtered": "/static/COVID19_HGI_ANA_C1_V2_20200701.txt.gz_1.0E-5.txt",
     "ANA_D1_V2_filtered": "/static/COVID19_HGI_ANA_D1_V2_20200701.txt.gz_1.0E-5.txt"
-  }
+  };
 
   const disabledElementList = [
     <option key="disabled" value="disabled" disabled>
       Select a GWAS Sample...
     </option>
-  ]
+  ];
 
   const gwasList = Object.keys(mock_data).map((x) => {
     return (

--- a/src/views/GwasBrowser.js
+++ b/src/views/GwasBrowser.js
@@ -12,8 +12,7 @@ class GwasBrowser extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            selectedGwasName: "",
-            selectedGwasURL: "",
+            selectedGwasName: ""
         }
         this.gwasFileList = {};
         this.igvOptions =  {
@@ -37,12 +36,11 @@ class GwasBrowser extends React.Component {
     }
     
     /*
-    * It is invoked immediately after updating occurs.
+    * Invoked when this.state.selectedGwasName is updated
     */
     componentDidUpdate(prevState) {
         if (this.state.selectedGwasName !== prevState.selectedGwasName) {
             var igvContainer = document.getElementById('igv-div');
-            igvContainer.innerHTML = "";
 
             this.igvOptions["tracks"][0]["name"] = this.state.selectedGwasName;
             this.igvOptions["tracks"][0]["url"] = BASE_URL + this.gwasFileList[this.state.selectedGwasName]
@@ -50,41 +48,47 @@ class GwasBrowser extends React.Component {
         }
     }
 
-
+    /**
+     * Invoked when a different option of dropdown is selected.
+     */
     handleGwasInputClick = (e) => {
         this.setState({ selectedGwasName: e.target.value});
     };
 
-  /*
-   * Create dropdown for gwas data files
-   * This method is invoked in render()
-  */
+    /*
+    * Create dropdown for gwas data files
+    * This method is invoked in render()
+    */
+    buildGwasList() {
+      // This should be replaced by an XHR request that retrieves a list of files from an API Server
+      var mock_data = {
+        "ANA_A2_V2_filtered": "/static/COVID19_HGI_ANA_A2_V2_20200701.txt.gz_1.0E-5.txt",
+        "ANA_B1_V2": "/static/COVID19_HGI_ANA_B1_V2.gwas", 
+        "ANA_B2_V2": "/static/minimal.gwas.1e-2.txt",
+        "ANA_C1_V2_filtered": "/static/COVID19_HGI_ANA_C1_V2_20200701.txt.gz_1.0E-5.txt",
+        "ANA_D1_V2_filtered": "/static/COVID19_HGI_ANA_D1_V2_20200701.txt.gz_1.0E-5.txt"
+      }
 
-  buildGwasList() {
+      this.gwasFileList = mock_data;
 
-    // This should be replaced by an XHR request that retrieves a list of files from an API Server
-    var mock_data = {
-      "ANA_A2_V2_filtered": "/static/COVID19_HGI_ANA_A2_V2_20200701.txt.gz_1.0E-5.txt",
-      "ANA_B1_V2": "/static/COVID19_HGI_ANA_B1_V2.gwas", 
-      "ANA_B2_V2": "/static/minimal.gwas.1e-2.txt",
-      "ANA_C1_V2_filtered": "/static/COVID19_HGI_ANA_C1_V2_20200701.txt.gz_1.0E-5.txt",
-      "ANA_D1_V2_filtered": "/static/COVID19_HGI_ANA_D1_V2_20200701.txt.gz_1.0E-5.txt"
+      return Object.keys(mock_data).map((x) => {
+          return (
+            <option key={x} value={x}>
+              {x}
+            </option>
+          );
+        });
     }
 
-    this.gwasFileList = mock_data;
 
-    return Object.keys(mock_data).map((x) => {
-      return (
-        <option key={x} value={x}>
-          {x}
-        </option>
-      );
-    });
-  }
-
-
+    /**
+     * Invoked when render() completes
+     * By default, load the first gwas file available.
+     */
     componentDidMount() {
       var igvContainer = document.getElementById('igv-div');
+
+      // Use the first gwas file name as the initial state
       this.state.selectedGwasName = Object.keys(this.gwasFileList)[0];
 
       this.igvOptions["tracks"][0]["name"] = this.state.selectedGwasName;
@@ -102,7 +106,6 @@ class GwasBrowser extends React.Component {
                         { this.buildGwasList()}
                     </Input>
                 </Row>
-
                 <div id="igv-div"></div>
             </div>
         </>

--- a/src/views/GwasBrowser.js
+++ b/src/views/GwasBrowser.js
@@ -40,6 +40,8 @@ class GwasBrowser extends React.Component {
      * Invoked when this.state.selectedGwasName is updated
      */
     componentDidUpdate(prevState) {
+      //TODO: Use igv.removeBrowser to remove existing browser instance
+
         if (this.state.selectedGwasName !== prevState.selectedGwasName) {
             this.igvOptions["tracks"][0]["name"] = this.state.selectedGwasName;
             this.igvOptions["tracks"][0]["url"] = BASE_URL + this.gwasFileList[this.state.selectedGwasName]

--- a/src/views/GwasBrowser.js
+++ b/src/views/GwasBrowser.js
@@ -83,8 +83,8 @@ function GwasBrowser() {
                     <span>
                       <p> Reminders: </p>
                       <p> Select a sample to get started. </p>
-                      <p> To adjust the range of data being plotted, click on the setting icon on the right
-                      of the track and select "Autoscale", or manually adjust the range by clicking on "Set data range".</p>
+                      <p> To adjust the range of data, click on the setting icon on the right of the track 
+                      and select "Autoscale", or manually adjust the range by clicking on "Set data range".</p>
                       <p> To adjust the height of the track, use "Set track height". </p>
                     </span>
                   </b>

--- a/src/views/GwasBrowser.js
+++ b/src/views/GwasBrowser.js
@@ -1,5 +1,4 @@
 import React, { ReactDOM } from "react";
-
 import { Row, Input } from "reactstrap";
 
 // TODO: Importing from igv.esm.min.js is not working, but it works fine in the standalone test
@@ -16,6 +15,7 @@ class GwasBrowser extends React.Component {
             selectedGwasName: "",
             selectedGwasURL: "",
         }
+        this.gwasFileList = {};
         this.igvOptions =  {
           genome: 'hg38',
           tracks: [
@@ -26,7 +26,6 @@ class GwasBrowser extends React.Component {
                 url: "",
                 indexed: false,
                 height: 300,
-                max: 25,
                 columns: {
                     chromosome: 1,
                     position: 2,
@@ -40,18 +39,20 @@ class GwasBrowser extends React.Component {
     /*
     * It is invoked immediately after updating occurs.
     */
-    componentDidUpdate(prevProps, prevState) {
-        if (this.state.selectedGwasURL !== prevState.selectedGwasURL) {
+    componentDidUpdate(prevState) {
+        if (this.state.selectedGwasName !== prevState.selectedGwasName) {
             var igvContainer = document.getElementById('igv-div');
-            this.igvOptions["tracks"][0]["url"] = this.state.selectedGwasURL;
-            return igv.createBrowser(igvContainer, this.igvOptions);
+            igvContainer.innerHTML = "";
+
+            this.igvOptions["tracks"][0]["name"] = this.state.selectedGwasName;
+            this.igvOptions["tracks"][0]["url"] = BASE_URL + this.gwasFileList[this.state.selectedGwasName]
+            igv.createBrowser(igvContainer, this.igvOptions);
         }
     }
 
 
-    handleTableClick = (e) => {
-        // this.setState({ selectedGwasName: e.target.key})
-        this.setState({ selectedGwasURL: e.target.value});
+    handleGwasInputClick = (e) => {
+        this.setState({ selectedGwasName: e.target.value});
     };
 
   /*
@@ -70,12 +71,11 @@ class GwasBrowser extends React.Component {
       "ANA_D1_V2_filtered": "/static/COVID19_HGI_ANA_D1_V2_20200701.txt.gz_1.0E-5.txt"
     }
 
-    // this.setState({ selectedGwasName: Object.keys(mock_data)[0]})
-    // this.setState({ selectedGwasURL: mock_data[Object.keys(mock_data)[0]]})
+    this.gwasFileList = mock_data;
 
     return Object.keys(mock_data).map((x) => {
       return (
-        <option key={x} value={BASE_URL + mock_data[x]}>
+        <option key={x} value={x}>
           {x}
         </option>
       );
@@ -85,8 +85,12 @@ class GwasBrowser extends React.Component {
 
     componentDidMount() {
       var igvContainer = document.getElementById('igv-div');
-      this.igvOptions["tracks"][0]["url"] = this.state.selectedGwasURL;
-      return igv.createBrowser(igvContainer, this.igvOptions);
+      this.state.selectedGwasName = Object.keys(this.gwasFileList)[0];
+
+      this.igvOptions["tracks"][0]["name"] = this.state.selectedGwasName;
+      this.igvOptions["tracks"][0]["url"] = BASE_URL + this.gwasFileList[this.state.selectedGwasName]
+
+      igv.createBrowser(igvContainer, this.igvOptions);
     }
 
     render() {
@@ -94,7 +98,7 @@ class GwasBrowser extends React.Component {
         <>
             <div className="content">
                 <Row>
-                    <Input onChange={this.handleTableClick} type="select">
+                    <Input onChange={this.handleGwasInputClick} type="select">
                         { this.buildGwasList()}
                     </Input>
                 </Row>

--- a/src/views/GwasBrowser.js
+++ b/src/views/GwasBrowser.js
@@ -29,7 +29,7 @@ function GwasBrowser() {
               position: 2,
               value: 5
           },
-          dotSize: 1.8
+          dotSize: 2.2
       }
   ]};
 
@@ -57,18 +57,17 @@ function GwasBrowser() {
 
   useEffect(() => {
     // Remove an existing browser instance
-    if (igv.getBrowser() !== undefined) {
+    while (igv.getBrowser() !== undefined) {
       igv.removeBrowser(igv.getBrowser());
     }
 
-    // Do not create new browser instance when nothing is selected
-    // This resolves a bug when two IGV instances are rendered
+    // Do not create new browser instance on page load as no sample is selected.
     if (selectedGwasName !== "") {
       igvOptions["tracks"][0]["name"] = selectedGwasName;
       igvOptions["tracks"][0]["url"] = BASE_URL + mock_data[selectedGwasName];
       igv.createBrowser(igvBrowser.current, igvOptions);
     }
-  })
+  }, [selectedGwasName, setSelectedGwasName])
 
   return (
     <>

--- a/src/views/GwasBrowser.js
+++ b/src/views/GwasBrowser.js
@@ -29,7 +29,7 @@ function GwasBrowser() {
               position: 2,
               value: 5
           },
-          dotSize: 1.5
+          dotSize: 1.8
       }
   ]};
 
@@ -40,6 +40,12 @@ function GwasBrowser() {
     "ANA_C1_V2_filtered": "/static/COVID19_HGI_ANA_C1_V2_20200701.txt.gz_1.0E-5.txt",
     "ANA_D1_V2_filtered": "/static/COVID19_HGI_ANA_D1_V2_20200701.txt.gz_1.0E-5.txt"
   }
+
+  const disabledElementList = [
+    <option key="disabled" value="disabled" disabled>
+      Select a GWAS Sample...
+    </option>
+  ]
 
   const gwasList = Object.keys(mock_data).map((x) => {
     return (
@@ -68,12 +74,12 @@ function GwasBrowser() {
     <>
         <div className="content">
             <Row>
-                <Input 
+                <Input defaultValue={'disabled'}
                   onChange={(e) => {
                     setSelectedGwasName(e.currentTarget.value);
                   }}
                   type="select">
-                  { gwasList }
+                  { disabledElementList.concat(gwasList) }
                 </Input>
             </Row>
             <div ref={igvBrowser}></div>

--- a/src/views/GwasBrowser.js
+++ b/src/views/GwasBrowser.js
@@ -1,0 +1,95 @@
+import React from "react";
+
+import { Row, Input } from "reactstrap";
+
+// Not sure why igv.esm.min.js is not working, it works fine in the standalone test
+import igv from 'igv/dist/igv.esm.js'
+
+class GwasBrowser extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            selectedGwas: ""
+        }
+    }
+    
+    /*
+    * It is invoked immediately after updating occurs.
+    */
+    componentDidUpdate(prevProps, prevState) {
+        if (this.state.selectedGwas !== prevState.selectedGwas) {
+            var igvContainer = document.getElementById('igv-div');
+            var igvOptions = {
+              genome: 'hg38', 
+              tracks: [
+                {
+                    type: "gwas",
+                    format: "gwas",
+                    name: "GWAS sample",
+                    url: this.state.selectedGwas,
+                    indexed: false,
+                    height: 300,
+                    max: 25,
+                    columns: {
+                        chromosome: 1,
+                        position: 2,
+                        value: 5
+                    },
+                    dotSize: 1.5
+                }
+            ]};
+            return igv.createBrowser(igvContainer, igvOptions);
+            
+        }
+    }
+
+    /*
+    */
+
+    handleTableClick = (e) => {
+        this.setState({ selectedGwas: e.target.value});
+    };
+
+
+    componentDidMount() {
+      var igvContainer = document.getElementById('igv-div');
+      var igvOptions = {
+        genome: 'hg38', 
+        tracks: [
+          {
+              type: "gwas",
+              format: "gwas",
+              name: "GWAS sample",
+              url: "http://ga4ghdev01.bcgsc.ca:20127/static/minimal.gwas.1e-2.txt",
+              indexed: false,
+              height: 300,
+              max: 25,
+              columns: {
+                  chromosome: 1,
+                  position: 2,
+                  value: 5
+              },
+              dotSize: 1.5
+          }
+      ]};
+      return igv.createBrowser(igvContainer, igvOptions);
+    }
+    render() {
+      return (
+        <>
+            <div className="content">
+                <Row>
+                    <Input onChange={this.handleTableClick} type="select">
+                        <option key={"1"} value={"http://ga4ghdev01.bcgsc.ca:20127/static/minimal.gwas.1e-2.txt"}>Sample 1</option>
+                        <option key={"2"} value={"http://ga4ghdev01.bcgsc.ca:20127/static/COVID19_HGI_ANA_B1_V2.gwas"}>Sample 2</option>
+                    </Input>
+                </Row>
+
+                <div id="igv-div"></div>
+            </div>
+        </>
+      );
+    }
+  }
+
+  export default GwasBrowser;

--- a/src/views/GwasBrowser.js
+++ b/src/views/GwasBrowser.js
@@ -1,4 +1,4 @@
-import React, { ReactDOM } from "react";
+import React from "react";
 import { Row, Input } from "reactstrap";
 
 // TODO: Importing from igv.esm.min.js is not working, but it works fine in the standalone test
@@ -14,6 +14,7 @@ class GwasBrowser extends React.Component {
         this.state = {
             selectedGwasName: ""
         }
+        this.igvBrowserRef = React.createRef();
         this.gwasFileList = {};
         this.igvOptions =  {
           genome: 'hg38',
@@ -40,12 +41,9 @@ class GwasBrowser extends React.Component {
      */
     componentDidUpdate(prevState) {
         if (this.state.selectedGwasName !== prevState.selectedGwasName) {
-            var igvContainer = document.getElementById('igv-div');
-            document.getElementById("igv-div").innerHTML = ""
-
             this.igvOptions["tracks"][0]["name"] = this.state.selectedGwasName;
             this.igvOptions["tracks"][0]["url"] = BASE_URL + this.gwasFileList[this.state.selectedGwasName]
-            igv.createBrowser(igvContainer, this.igvOptions);
+            igv.createBrowser(this.igvBrowserRef.current, this.igvOptions);
         }
     }
 
@@ -87,15 +85,12 @@ class GwasBrowser extends React.Component {
      * By default, load the first gwas file available.
      */
     componentDidMount() {
-      var igvContainer = document.getElementById('igv-div');
-
       // Use the first gwas file name as the initial state
       this.setState({ selectedGwasName: Object.keys(this.gwasFileList)[0] });
-
       this.igvOptions["tracks"][0]["name"] = this.state.selectedGwasName;
       this.igvOptions["tracks"][0]["url"] = BASE_URL + this.gwasFileList[this.state.selectedGwasName]
 
-      igv.createBrowser(igvContainer, this.igvOptions);
+      igv.createBrowser(this.igvBrowserRef.current, this.igvOptions);
     }
 
     render() {
@@ -107,7 +102,7 @@ class GwasBrowser extends React.Component {
                         { this.buildGwasList() }
                     </Input>
                 </Row>
-                <div id="igv-div"></div>
+                <div ref={this.igvBrowserRef}></div>
             </div>
         </>
       );

--- a/src/views/GwasBrowser.js
+++ b/src/views/GwasBrowser.js
@@ -1,87 +1,101 @@
-import React from "react";
+import React, { ReactDOM } from "react";
 
 import { Row, Input } from "reactstrap";
 
-// Not sure why igv.esm.min.js is not working, it works fine in the standalone test
+// TODO: Importing from igv.esm.min.js is not working, but it works fine in the standalone test
 import igv from 'igv/dist/igv.esm.js'
+
+// Consts
+import BASE_URL from "../constants/constants.js"
+
 
 class GwasBrowser extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            selectedGwas: ""
+            selectedGwasName: "",
+            selectedGwasURL: "",
         }
+        this.igvOptions =  {
+          genome: 'hg38',
+          tracks: [
+            {
+                type: "gwas",
+                format: "gwas",
+                name: "",
+                url: "",
+                indexed: false,
+                height: 300,
+                max: 25,
+                columns: {
+                    chromosome: 1,
+                    position: 2,
+                    value: 5
+                },
+                dotSize: 1.5
+            }
+        ]}
     }
     
     /*
     * It is invoked immediately after updating occurs.
     */
     componentDidUpdate(prevProps, prevState) {
-        if (this.state.selectedGwas !== prevState.selectedGwas) {
+        if (this.state.selectedGwasURL !== prevState.selectedGwasURL) {
             var igvContainer = document.getElementById('igv-div');
-            var igvOptions = {
-              genome: 'hg38', 
-              tracks: [
-                {
-                    type: "gwas",
-                    format: "gwas",
-                    name: "GWAS sample",
-                    url: this.state.selectedGwas,
-                    indexed: false,
-                    height: 300,
-                    max: 25,
-                    columns: {
-                        chromosome: 1,
-                        position: 2,
-                        value: 5
-                    },
-                    dotSize: 1.5
-                }
-            ]};
-            return igv.createBrowser(igvContainer, igvOptions);
-            
+            this.igvOptions["tracks"][0]["url"] = this.state.selectedGwasURL;
+            return igv.createBrowser(igvContainer, this.igvOptions);
         }
     }
 
-    /*
-    */
 
     handleTableClick = (e) => {
-        this.setState({ selectedGwas: e.target.value});
+        // this.setState({ selectedGwasName: e.target.key})
+        this.setState({ selectedGwasURL: e.target.value});
     };
+
+  /*
+   * Create dropdown for gwas data files
+   * This method is invoked in render()
+  */
+
+  buildGwasList() {
+
+    // This should be replaced by an XHR request that retrieves a list of files from an API Server
+    var mock_data = {
+      "ANA_A2_V2_filtered": "/static/COVID19_HGI_ANA_A2_V2_20200701.txt.gz_1.0E-5.txt",
+      "ANA_B1_V2": "/static/COVID19_HGI_ANA_B1_V2.gwas", 
+      "ANA_B2_V2": "/static/minimal.gwas.1e-2.txt",
+      "ANA_C1_V2_filtered": "/static/COVID19_HGI_ANA_C1_V2_20200701.txt.gz_1.0E-5.txt",
+      "ANA_D1_V2_filtered": "/static/COVID19_HGI_ANA_D1_V2_20200701.txt.gz_1.0E-5.txt"
+    }
+
+    // this.setState({ selectedGwasName: Object.keys(mock_data)[0]})
+    // this.setState({ selectedGwasURL: mock_data[Object.keys(mock_data)[0]]})
+
+    return Object.keys(mock_data).map((x) => {
+      return (
+        <option key={x} value={BASE_URL + mock_data[x]}>
+          {x}
+        </option>
+      );
+    });
+  }
 
 
     componentDidMount() {
       var igvContainer = document.getElementById('igv-div');
-      var igvOptions = {
-        genome: 'hg38', 
-        tracks: [
-          {
-              type: "gwas",
-              format: "gwas",
-              name: "GWAS sample",
-              url: "http://ga4ghdev01.bcgsc.ca:20127/static/minimal.gwas.1e-2.txt",
-              indexed: false,
-              height: 300,
-              max: 25,
-              columns: {
-                  chromosome: 1,
-                  position: 2,
-                  value: 5
-              },
-              dotSize: 1.5
-          }
-      ]};
-      return igv.createBrowser(igvContainer, igvOptions);
+      this.igvOptions["tracks"][0]["url"] = this.state.selectedGwasURL;
+      return igv.createBrowser(igvContainer, this.igvOptions);
     }
+
     render() {
       return (
         <>
             <div className="content">
                 <Row>
                     <Input onChange={this.handleTableClick} type="select">
-                        <option key={"1"} value={"http://ga4ghdev01.bcgsc.ca:20127/static/minimal.gwas.1e-2.txt"}>Sample 1</option>
-                        <option key={"2"} value={"http://ga4ghdev01.bcgsc.ca:20127/static/COVID19_HGI_ANA_B1_V2.gwas"}>Sample 2</option>
+                        { this.buildGwasList()}
                     </Input>
                 </Row>
 
@@ -91,5 +105,10 @@ class GwasBrowser extends React.Component {
       );
     }
   }
+
+//   ReactDOM.render(
+//     <GwasBrowser />,
+//     document.getElementById('root')
+//   );
 
   export default GwasBrowser;


### PR DESCRIPTION
This PR includes a new view and a new component

The `view/gwas_browser.js` includes an input for users to select GWAS samples from, and an IGV.js instance.

The `components/IGV/GwasInstance.js` includes an IGV.js browser that has pre-set parameters for GWAS data handling. This component could possibly be further extended to be a more general-purpose IGV browser, pending our future use-cases.