### PR TITLE
add new route

### DIFF
--- a/src/components/IGV/GwasInstance.js
+++ b/src/components/IGV/GwasInstance.js
@@ -39,7 +39,7 @@ function GwasInstance({selectedGwasName, selectedGwasUrl}) {
             igvOptions["tracks"][0]["url"] = selectedGwasUrl;
             igv.createBrowser(igvBrowser.current, igvOptions);
         }
-    });
+    }, [selectedGwasName]);
 
     return (
         <div 

--- a/src/routes.js
+++ b/src/routes.js
@@ -27,6 +27,7 @@ import Services from "views/Services.js";
 import APIInfo from "views/APIInfo.js";
 import CustomVisualization from "views/CustomVisualization";
 import PatientsOverview from "views/PatientsOverview";
+import GwasBrowser from "views/GwasBrowser";
 
 var routes = [
   {
@@ -55,6 +56,13 @@ var routes = [
     name: "API info",
     icon: "nc-icon nc-sound-wave",
     component: APIInfo,
+    layout: "/dashboard",
+  },
+  {
+    path: "/gwas_browser",
+    name: "GWAS Browser",
+    icon: "nc-icon nc-compass-05",
+    component: GwasBrowser,
     layout: "/dashboard",
   },
   {


### PR DESCRIPTION
This PR

- Fixes a bug when switching dataset causes the `useEffect` to re-run, where it should have no effect.
- Adds the route to the gwas browser.